### PR TITLE
Add UManitoba attendees

### DIFF
--- a/Meetings/2017_09_11.md
+++ b/Meetings/2017_09_11.md
@@ -13,7 +13,7 @@ This meeting is a hybrid teleconference and IRC chat. Anyone is welcome to join.
 * Time: 1:00pm Eastern Daylight Time US (UTC-4)
 * Dial-in Number: (641) 715-3570
   * Participant Code: 304589#
-  * International numbers: [[Conference Call Information]]
+  * International numbers: [Conference Call Information](https://github.com/Islandora-CLAW/CLAW/wiki/Conference-Call-Information)
   * Web Access: https://www.freeconferencecallhd.com/wp-content/themes/responsive/flashphone/flash-phone.php
 * IRC:
   * Join the #islandora chat room via [Freenode Web IRC](http://webchat.freenode.net/) (enter a unique nick)

--- a/Participants.md
+++ b/Participants.md
@@ -24,3 +24,5 @@
 * Audrey Sage Lorberfeld (The New York Academy of Medicine) 
 * Robin Naughton (The New York Academy of Medicine)
 * Rachel Tillay (Tulane University)
+* Christine Bone (University of Manitoba)
+* Les Moor (University of Manitoba)


### PR DESCRIPTION
Also fix the Conference Call link to international numbers in the meeting agenda.